### PR TITLE
Allow eval'd results to be returned, added browserify step.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telejson",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "",
   "keywords": [
     "JSON",
@@ -28,7 +28,8 @@
   "jsnext:main": "src/index.js",
   "scripts": {
     "test": "jest",
-    "prepublish": "babel src --out-dir dist"
+    "prepublish": "babel src --out-dir dist",
+    "browserify": "browserify dist/index.js --s telejson > dist/telejson.js"
   },
   "dependencies": {
     "global": "^4.3.2",

--- a/src/index.js
+++ b/src/index.js
@@ -226,7 +226,7 @@ export const reviver = function reviver() {
       // lazy eval of the function
       const result = (...args) => {
         const f = eval(`(${source})`);
-        f(...args);
+        return f(...args);
       };
       Object.defineProperty(result, 'toString', {
         value: () => source,


### PR DESCRIPTION
Hey, thanks a lot for this library.

I've added a couple of changes:
  - Results from serialized functions can be returned when invoked.
  - Added a [browserify](http://browserify.org/) step to enable use on the web.
  - Bumped the package version to `2.2.2`.

Thanks again!