### PR TITLE
Add option to disable lazy eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ Only relevant when using `stringify`.
 
 ### reviver
 
-Doesn't take any options right now.
+`lazyEval`: When set to false, lazy eval will be disabled. (default true)
+
+Note: disabling lazy eval will affect performance. Consider disabling it only if you truly need to.
 
 ## Contributing
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,7 @@ interface Options {
   allowClass: boolean;
   maxDepth: number;
   space: number | undefined;
+  lazyEval: boolean;
 }
 
 export const replacer = function replacer(options: Options) {
@@ -229,7 +230,7 @@ interface ValueContainer {
   [keys: string]: any;
 }
 
-export const reviver = function reviver() {
+export const reviver = function reviver(options: Options) {
   const refs: { target: string; container: { [keys: string]: any }; replacement: string }[] = [];
   let root: any;
 
@@ -269,6 +270,10 @@ export const reviver = function reviver() {
 
     if (typeof value === 'string' && value.startsWith('_function_')) {
       const [, name, source] = value.match(/_function_([^|]*)\|(.*)/) || [];
+
+      if (!options.lazyEval) {
+        return eval(`(${source})`);
+      }
 
       // lazy eval of the function
       const result = (...args: any[]) => {
@@ -332,6 +337,7 @@ const defaultOptions: Options = {
   allowClass: true,
   allowUndefined: true,
   allowSymbol: true,
+  lazyEval: true,
 };
 
 export const stringify = (data: any, options: Partial<Options> = {}) => {
@@ -364,8 +370,9 @@ const mutator = () => {
   };
 };
 
-export const parse = (data: string) => {
-  const result = JSON.parse(data, reviver());
+export const parse = (data: string, options: Partial<Options> = {}) => {
+  const mergedOptions: Options = Object.assign({}, defaultOptions, options);
+  const result = JSON.parse(data, reviver(mergedOptions));
 
   mutator()(result);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,27 @@ const cleanCode = memoize(10000)(code =>
     .trim()
 );
 
+const convertShorthandMethods = function(key: string, stringified: string) {
+  const fnHead = stringified.slice(0, stringified.indexOf('{'));
+  const fnBody = stringified.slice(stringified.indexOf('{'));
+
+  if (fnHead.includes('=>')) {
+    // This is an arrow function
+    return stringified;
+  }
+
+  if (fnHead.includes('function')) {
+    // This is an anonymous function
+    return stringified;
+  }
+
+  let modifiedHead = fnHead;
+
+  modifiedHead = modifiedHead.replace(key, 'function');
+
+  return modifiedHead + fnBody;
+};
+
 const dateFormat = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/;
 
 interface Options {
@@ -115,7 +136,7 @@ export const replacer = function replacer(options: Options) {
           /(\[native code\]|WEBPACK_IMPORTED_MODULE|__webpack_exports__|__webpack_require__)/
         )
       ) {
-        return `_function_${name}|${cleanCode(stringified)}`;
+        return `_function_${name}|${cleanCode(convertShorthandMethods(key, stringified))}`;
       }
       return `_function_${name}|${(() => {}).toString()}`;
     }

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -7,6 +7,7 @@ Object {
   "fn1": [Function],
   "fn2": [Function],
   "fn3": [Function],
+  "fn4": [Function],
   "foo": Foo {},
   "nested": Object {
     "a": Object {
@@ -43,6 +44,7 @@ exports[`Dist space 1`] = `
   \\"fn1\\": \\"_function_fn1|function fn1(x) {return x + x;}\\",
   \\"fn2\\": \\"_function_x|function x(x) {return x - x;}\\",
   \\"fn3\\": \\"_function_fn3|function fn3() {return x / x;}\\",
+  \\"fn4\\": \\"_function_fn4|function fn4(x) {return x * x;}\\",
   \\"date\\": \\"_date_2018-01-01T00:00:00.000Z\\",
   \\"foo\\": {
     \\"_constructor-name_\\": \\"Foo\\"
@@ -72,7 +74,7 @@ exports[`Dist space 1`] = `
 }"
 `;
 
-exports[`Dist stringify 1`] = `"{\\"regex1\\":\\"_regexp_|foo\\",\\"regex2\\":\\"_regexp_g|foo\\",\\"regex3\\":\\"_regexp_i|foo\\",\\"fn1\\":\\"_function_fn1|function fn1(x) {return x + x;}\\",\\"fn2\\":\\"_function_x|function x(x) {return x - x;}\\",\\"fn3\\":\\"_function_fn3|function fn3() {return x / x;}\\",\\"date\\":\\"_date_2018-01-01T00:00:00.000Z\\",\\"foo\\":{\\"_constructor-name_\\":\\"Foo\\"},\\"nested\\":{\\"a\\":{\\"b\\":{\\"c\\":{\\"d\\":{\\"e\\":{\\"f\\":{\\"g\\":{\\"h\\":{\\"i\\":{\\"j\\":\\"[Object]\\"}}}}}}}}}},\\"cyclic\\":\\"_duplicate_root\\"}"`;
+exports[`Dist stringify 1`] = `"{\\"regex1\\":\\"_regexp_|foo\\",\\"regex2\\":\\"_regexp_g|foo\\",\\"regex3\\":\\"_regexp_i|foo\\",\\"fn1\\":\\"_function_fn1|function fn1(x) {return x + x;}\\",\\"fn2\\":\\"_function_x|function x(x) {return x - x;}\\",\\"fn3\\":\\"_function_fn3|function fn3() {return x / x;}\\",\\"fn4\\":\\"_function_fn4|function fn4(x) {return x * x;}\\",\\"date\\":\\"_date_2018-01-01T00:00:00.000Z\\",\\"foo\\":{\\"_constructor-name_\\":\\"Foo\\"},\\"nested\\":{\\"a\\":{\\"b\\":{\\"c\\":{\\"d\\":{\\"e\\":{\\"f\\":{\\"g\\":{\\"h\\":{\\"i\\":{\\"j\\":\\"[Object]\\"}}}}}}}}}},\\"cyclic\\":\\"_duplicate_root\\"}"`;
 
 exports[`Source parse 1`] = `
 Object {
@@ -81,6 +83,7 @@ Object {
   "fn1": [Function],
   "fn2": [Function],
   "fn3": [Function],
+  "fn4": [Function],
   "foo": Foo {},
   "nested": Object {
     "a": Object {
@@ -117,6 +120,7 @@ exports[`Source space 1`] = `
   \\"fn1\\": \\"_function_fn1|function fn1(x) {return x + x;}\\",
   \\"fn2\\": \\"_function_x|function x(x) {return x - x;}\\",
   \\"fn3\\": \\"_function_fn3|function fn3() {return x / x;}\\",
+  \\"fn4\\": \\"_function_fn4|function fn4(x) {return x * x;}\\",
   \\"date\\": \\"_date_2018-01-01T00:00:00.000Z\\",
   \\"foo\\": {
     \\"_constructor-name_\\": \\"Foo\\"
@@ -146,4 +150,4 @@ exports[`Source space 1`] = `
 }"
 `;
 
-exports[`Source stringify 1`] = `"{\\"regex1\\":\\"_regexp_|foo\\",\\"regex2\\":\\"_regexp_g|foo\\",\\"regex3\\":\\"_regexp_i|foo\\",\\"fn1\\":\\"_function_fn1|function fn1(x) {return x + x;}\\",\\"fn2\\":\\"_function_x|function x(x) {return x - x;}\\",\\"fn3\\":\\"_function_fn3|function fn3() {return x / x;}\\",\\"date\\":\\"_date_2018-01-01T00:00:00.000Z\\",\\"foo\\":{\\"_constructor-name_\\":\\"Foo\\"},\\"nested\\":{\\"a\\":{\\"b\\":{\\"c\\":{\\"d\\":{\\"e\\":{\\"f\\":{\\"g\\":{\\"h\\":{\\"i\\":{\\"j\\":\\"[Object]\\"}}}}}}}}}},\\"cyclic\\":\\"_duplicate_root\\"}"`;
+exports[`Source stringify 1`] = `"{\\"regex1\\":\\"_regexp_|foo\\",\\"regex2\\":\\"_regexp_g|foo\\",\\"regex3\\":\\"_regexp_i|foo\\",\\"fn1\\":\\"_function_fn1|function fn1(x) {return x + x;}\\",\\"fn2\\":\\"_function_x|function x(x) {return x - x;}\\",\\"fn3\\":\\"_function_fn3|function fn3() {return x / x;}\\",\\"fn4\\":\\"_function_fn4|function fn4(x) {return x * x;}\\",\\"date\\":\\"_date_2018-01-01T00:00:00.000Z\\",\\"foo\\":{\\"_constructor-name_\\":\\"Foo\\"},\\"nested\\":{\\"a\\":{\\"b\\":{\\"c\\":{\\"d\\":{\\"e\\":{\\"f\\":{\\"g\\":{\\"h\\":{\\"i\\":{\\"j\\":\\"[Object]\\"}}}}}}}}}},\\"cyclic\\":\\"_duplicate_root\\"}"`;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -50,6 +50,9 @@ const data = {
   fn1,
   fn2,
   fn3,
+  fn4(x) {
+    return x * x;
+  },
   date,
   foo: new Foo(),
   nested,
@@ -57,69 +60,69 @@ const data = {
 
 data.cyclic = data;
 
-const tests = ({stringify, parse}) => {
+const tests = ({ stringify, parse }) => {
   test('sanity', () => {
     expect(true).toBe(true);
   });
-  
+
   test('stringify', () => {
     let stringified;
-  
+
     expect(() => (stringified = stringify(data))).not.toThrow();
     expect(stringified).toMatchSnapshot();
   });
-  
+
   test('parse', () => {
     const stringified = stringify(data);
     let parsed;
     expect(() => (parsed = parse(stringified))).not.toThrow();
     expect(parsed).toMatchSnapshot();
-  
+
     // test the regex
     expect(parsed.regex1.exec).toBeDefined();
     expect('aaa-foo-foo-bbb'.replace(parsed.regex1, 'BAR')).toBe('aaa-BAR-foo-bbb');
     expect('aaa-foo-foo-bbb'.replace(parsed.regex2, 'BAR')).toBe('aaa-BAR-BAR-bbb');
     expect('aaa-Foo-foo-bbb'.replace(parsed.regex3, 'BAR')).toBe('aaa-BAR-foo-bbb');
-  
+
     // test the date
     expect(parsed.date).toBeInstanceOf(Date);
     expect(parsed.date.getFullYear()).toBe(2018);
-  
+
     // test cyclic
     expect(parsed.cyclic.cyclic.cyclic.cyclic).toBeDefined();
     expect(parsed.cyclic.cyclic.cyclic.cyclic).toBe(parsed);
-  
+
     // test Foo instance
     expect(parsed.foo).toBeDefined();
     expect(parsed.foo.constructor.name).toBe('Foo');
     expect(parsed.foo instanceof Foo).toBe(false);
   });
-  
+
   test('maxDepth', () => {
     const stringifiedDefault = stringify(data);
     const stringifiedMax5 = stringify(data, { maxDepth: 5 });
     const parsedDefault = parse(stringifiedDefault);
     const parsedMax5 = parse(stringifiedMax5);
-  
+
     expect(parsedDefault.nested.a.b.c.d.e.f.g.h.i).toBeDefined();
     expect(parsedDefault.nested.a.b.c.d.e.f.g.h.i.j).toBeDefined();
     expect(parsedDefault.nested.a.b.c.d.e.f.g.h.i.j.k).not.toBeDefined();
-  
+
     expect(parsedMax5.nested.a.b.c.d).toBeDefined();
     expect(parsedMax5.nested.a.b.c.d.e).toBeDefined();
     expect(parsedMax5.nested.a.b.c.d.e.f).not.toBeDefined();
   });
-  
+
   test('space', () => {
     const stringifiedSpaced = stringify(data, { space: 2 });
-  
+
     expect(stringifiedSpaced).toMatchSnapshot();
   });
-  
+
   test('stringify the global object', () => {
     expect(() => stringify(global, { maxDepth: 10000 })).not.toThrow();
   });
-  
+
   test('check duplicate value', () => {
     const Fruit = {
       apple: true,
@@ -128,34 +131,34 @@ const tests = ({stringify, parse}) => {
     Fruit.cyclic = Fruit;
     const stringified = stringify(Fruit);
     const parsed = parse(stringified);
-  
+
     expect(stringified).toEqual('{"apple":true,"parent":{},"cyclic":"_duplicate_root"}');
     expect(parsed.cyclic.cyclic.cyclic.cyclic).toBeDefined();
     expect(parsed.cyclic).toBe(parsed);
     expect(parsed.cyclic.cyclic.cyclic.cyclic).toBe(parsed);
   });
-  
+
   test('check constructor value', () => {
     const data = { ConstructorFruit: new Foo() };
-  
+
     const stringified = stringify(data);
     const parsed = parse(stringified);
-  
+
     expect(stringified).toEqual('{"ConstructorFruit":{"_constructor-name_":"Foo"}}');
     expect(parsed.ConstructorFruit).toBeDefined();
     expect(parsed.ConstructorFruit.constructor.name).toBe('Foo');
     expect(parsed.foo instanceof Foo).toBe(false);
   });
-  
+
   test('check function value', () => {
     const Fruit = function(value) {
       return [value, 'apple'];
     };
     const data = { FunctionFruit: Fruit };
-  
+
     const stringified = stringify(data);
     const parsed = parse(stringified);
-  
+
     expect(stringified).toEqual(
       '{"FunctionFruit":"_function_Fruit|function Fruit(value) {return [value, \'apple\'];}"}'
     );
@@ -164,79 +167,79 @@ const tests = ({stringify, parse}) => {
       "function Fruit(value) {return [value, 'apple'];}"
     );
   });
-  
+
   test('check regExp value', () => {
     const data = { RegExpFruit: /test/g };
-  
+
     const stringified = stringify(data);
     const parsed = parse(stringified);
-  
+
     expect(stringified).toEqual('{"RegExpFruit":"_regexp_g|test"}');
     expect(parsed).toMatchObject(data);
   });
-  
+
   test('check date value', () => {
     const data = { DateFruit: new Date('01.01.2019') };
-  
+
     const stringified = stringify(data);
     const parsed = parse(stringified);
-  
+
     expect(stringified).toEqual('{"DateFruit":"_date_2019-01-01T00:00:00.000Z"}');
     expect(parsed).toMatchObject(data);
     expect(parsed.DateFruit.getFullYear()).toBe(2019);
   });
-  
+
   test('check symbol value', () => {
     const data = { SymbleFruit: Symbol('apple') };
-  
+
     const stringified = stringify(data);
     const parsed = parse(stringified);
-  
+
     expect(stringified).toEqual('{"SymbleFruit":"_symbol_apple"}');
     expect(parsed.SymbleFruit.toString()).toEqual('Symbol(apple)');
   });
-  
+
   test('check minus Infinity value', () => {
     const data = { InfinityFruit: -Infinity };
-  
+
     const stringified = stringify(data);
     const parsed = parse(stringified);
-  
+
     expect(stringified).toEqual('{"InfinityFruit":"_-Infinity_"}');
     expect(parsed).toMatchObject(data);
   });
-  
+
   test('check Infinity value', () => {
     const data = { InfinityFruit: Infinity };
-  
+
     const stringified = stringify(data);
     const parsed = parse(stringified);
-  
+
     expect(stringified).toEqual('{"InfinityFruit":"_Infinity_"}');
     expect(parsed).toMatchObject(data);
   });
-  
+
   test('check NaN value', () => {
     const data = { NaNFruit: NaN };
-  
+
     const stringified = stringify(data);
     const parsed = parse(stringified);
-  
+
     expect(stringified).toEqual('{"NaNFruit":"_NaN_"}');
     expect(parsed).toMatchObject(data);
   });
-  
+
   test('check undefined value', () => {
     const data = { undefinedFruit: undefined };
-  
+
     const stringified = stringify(data);
     const parsed = parse(stringified);
-  
+
     expect(stringified).toEqual('{"undefinedFruit":"_undefined_"}');
     expect(parsed.undefinedFruit).toEqual(undefined);
     expect(Object.keys(parsed)).toEqual(['undefinedFruit']);
   });
-  
+
   test('primitives should not be deduplicated', () => {
     const data = {
       bool: true,
@@ -255,16 +258,16 @@ const tests = ({stringify, parse}) => {
         },
       },
     };
-  
+
     const stringified = stringify(data);
     const parsed = parse(stringified);
-  
+
     expect(stringified).toEqual(
       '{"bool":true,"a":1,"b":"1","c":{"bool":true,"c":1,"d":3,"e":"3","f":{"bool":true,"c":"1","d":3,"e":"3"}}}'
     );
     expect(parsed).toMatchObject(data);
   });
-  
+
   test('bug', () => {
     const data = {
       a: 1,
@@ -274,31 +277,30 @@ const tests = ({stringify, parse}) => {
       e: {
         1: data,
       },
-      f: [1,2,3,4,5],
+      f: [1, 2, 3, 4, 5],
       g: undefined,
       h: null,
       i: () => {},
-      j: function(){}
+      j: function() {},
     };
-  
+
     const stringified = stringify(data);
-    expect(stringified).toMatch("{\"a\":1,\"b\":\"2\",\"c\":\"_NaN_\",\"d\":true,\"e\":{\"1\":\"_undefined_\"},\"f\":[1,2,3,4,5],\"g\":\"_undefined_\",\"h\":null,\"i\":\"_function_i|function i() {}\",\"j\":\"_function_j|function j() {}\"}")
-  
+    expect(stringified).toMatch(
+      '{"a":1,"b":"2","c":"_NaN_","d":true,"e":{"1":"_undefined_"},"f":[1,2,3,4,5],"g":"_undefined_","h":null,"i":"_function_i|function i() {}","j":"_function_j|function j() {}"}'
+    );
+
     const parsed = parse(stringified);
-  
+
     Object.entries(parsed).forEach((k, v) => {
       expect(data[k]).toEqual(parsed[k]);
-    })
+    });
   });
-  
-}
+};
 
+describe('Source', () => {
+  tests(src);
+});
 
-describe('Source',() => {
-  tests(src)
-})
-
-describe('Dist',() => {
-  tests(dist)
-})
-
+describe('Dist', () => {
+  tests(dist);
+});


### PR DESCRIPTION
Using lazy eval executes eval without having the proper "this" bound. This PR adds an option to the reviver to disable lazy eval.

## Example

```javascript
const telejson = require('telejson');

let testobj = {
  message: 'bar',
  foo() {
    return this.message;
  }
};

console.log('before', testobj.foo());
// "bar"

let stringified = telejson.stringify(testobj);

let parsedObj = telejson.parse(stringified);

console.log('telejson', parsedObj.foo());
// TypeError: Cannot read property 'message' of undefined

```