### PR TITLE
Add option disable lazy eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ Only relevant when using `stringify`.
 
 ### reviver
 
-Doesn't take any options right now.
+`lazyEval`: When set to false, lazy eval will be disabled. (default true)
+
+Note: disabling lazy eval will affect performance. Consider disabling it only if you truly need to.
 
 ## Contributing
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,6 +251,7 @@ export const reviver = function reviver(options: Options) {
       const [, name, source] = value.match(/_function_([^|]*)\|(.*)/) || [];
 
       if (!options.lazyEval) {
+        // eslint-disable-next-line no-eval
         return eval(`(${source})`);
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ interface Options {
   allowClass: boolean;
   maxDepth: number;
   space: number | undefined;
+  lazyEval: boolean;
 }
 
 export const replacer = function replacer(options: Options) {
@@ -208,7 +209,7 @@ interface ValueContainer {
   [keys: string]: any;
 }
 
-export const reviver = function reviver() {
+export const reviver = function reviver(options: Options) {
   const refs: { target: string; container: { [keys: string]: any }; replacement: string }[] = [];
   let root: any;
 
@@ -248,6 +249,10 @@ export const reviver = function reviver() {
 
     if (typeof value === 'string' && value.startsWith('_function_')) {
       const [, name, source] = value.match(/_function_([^|]*)\|(.*)/) || [];
+
+      if (!options.lazyEval) {
+        return eval(`(${source})`);
+      }
 
       // lazy eval of the function
       const result = (...args: any[]) => {
@@ -311,6 +316,7 @@ const defaultOptions: Options = {
   allowClass: true,
   allowUndefined: true,
   allowSymbol: true,
+  lazyEval: true,
 };
 
 export const stringify = (data: any, options: Partial<Options> = {}) => {
@@ -343,8 +349,9 @@ const mutator = () => {
   };
 };
 
-export const parse = (data: string) => {
-  const result = JSON.parse(data, reviver());
+export const parse = (data: string, options: Partial<Options> = {}) => {
+  const mergedOptions: Options = Object.assign({}, defaultOptions, options);
+  const result = JSON.parse(data, reviver(mergedOptions));
 
   mutator()(result);
 


### PR DESCRIPTION
Using lazy eval executes eval without having the proper "this" bound. This PR adds an option to the reviver to disable lazy eval.

## Example

```javascript
const telejson = require('telejson');

let testobj = {
  message: 'bar',
  foo() {
    return this.message;
  }
};

console.log('before', testobj.foo());
// "bar"

let stringified = telejson.stringify(testobj);

let parsedObj = telejson.parse(stringified);

console.log('telejson', parsedObj.foo());
// TypeError: Cannot read property 'message' of undefined

```