### PR TITLE
Use is-regex v1.1.1 which fixes performance regression in v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/is-function": "^1.0.0",
     "global": "^4.4.0",
     "is-function": "^1.0.2",
-    "is-regex": "^1.1.0",
+    "is-regex": "^1.1.1",
     "is-symbol": "^1.0.3",
     "isobject": "^4.0.0",
     "lodash": "^4.17.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3637,10 +3637,10 @@ is-regex@^1.0.5:
   dependencies:
     has "^1.0.3"
 
-is-regex@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.0.tgz#ece38e389e490df0dc21caea2bd596f987f767ff"
-  integrity sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==
+is-regex@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
+  integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
   dependencies:
     has-symbols "^1.0.1"
 


### PR DESCRIPTION
This pulls in the `is-regex` performance improvements mentioned in #43 — the perf regression was introduced in inspect-js/is-regex#28 and fixed in inspect-js/is-regex#30.

- [x] Tests pass

cc @phated @ndelangen @shilman 