### PR TITLE
Perf: Reorganize fast checks to the top of replacer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,42 @@ export const replacer = function replacer(options: Options) {
         keys.pop();
       }
 
+      if (typeof value === 'boolean') {
+        return value;
+      }
+
+      if (value === undefined) {
+        if (!options.allowUndefined) {
+          return undefined;
+        }
+        return '_undefined_';
+      }
+
+      if (typeof value === 'number') {
+        if (value === -Infinity) {
+          return '_-Infinity_';
+        }
+        if (value === Infinity) {
+          return '_Infinity_';
+        }
+        if (Number.isNaN(value)) {
+          return '_NaN_';
+        }
+
+        return value;
+      }
+
+      if (typeof value === 'string') {
+        if (dateFormat.test(value)) {
+          if (!options.allowDate) {
+            return undefined;
+          }
+          return `_date_${value}`;
+        }
+
+        return value;
+      }
+
       if (isRegExp(value)) {
         if (!options.allowRegExp) {
           return undefined;
@@ -147,42 +183,6 @@ export const replacer = function replacer(options: Options) {
           return undefined;
         }
         return `_symbol_${value.toString().slice(7, -1)}`;
-      }
-
-      if (typeof value === 'string' && dateFormat.test(value)) {
-        if (!options.allowDate) {
-          return undefined;
-        }
-        return `_date_${value}`;
-      }
-
-      if (value === undefined) {
-        if (!options.allowUndefined) {
-          return undefined;
-        }
-        return '_undefined_';
-      }
-
-      if (typeof value === 'number') {
-        if (value === -Infinity) {
-          return '_-Infinity_';
-        }
-        if (value === Infinity) {
-          return '_Infinity_';
-        }
-        if (Number.isNaN(value)) {
-          return '_NaN_';
-        }
-
-        return value;
-      }
-
-      if (typeof value === 'string') {
-        return value;
-      }
-
-      if (typeof value === 'boolean') {
-        return value;
       }
 
       if (stack.length >= options.maxDepth) {


### PR DESCRIPTION
As mentioned in https://github.com/storybookjs/telejson/issues/42#issuecomment-668858247, this moves the fast type checks to the top of the replacer function so it can exit as quickly as possible when dealing with simple values. In my testing, this improves performance of stringify by 10-20% more (saving ~20-40ms in the storybook I was testing).