### PR TITLE
CI: Run tests against Node 12, 14 and 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,29 @@
-version: 2
+version: 2.1
+
+orbs:
+  node: circleci/node@4.3.0
 
 jobs:
-  test:
+  test-with-node:
+    parameters:
+      node-version:
+        type: string
     docker:
-      - image: circleci/node:10
+      - image: cimg/base:stable
     steps:
       - checkout
+      - node/install:
+          node-version: << parameters.node-version >>
+          install-yarn: true
       - run: yarn install
       - run: yarn build
       - run: yarn lint
       - run: yarn test
 
 workflows:
-  version: 2
-
   build_and_test:
     jobs:
-      - test
+      - test-with-node:
+          matrix:
+            parameters:
+              node-version: ["12", "14", "16"]


### PR DESCRIPTION
**Description**

As I will be doing some changes in the next few days/weeks to address a few bugs I would feel more confident if I would be sure I'm not breaking things for a specific version of Node. So I updated the CircleCI config to run the "build" + test job against 3 latest LTS versions of Node: 12, 14 and 16. I haven't added Node 10 on purpose because it is now (in 2 days 🙈 ) EOL.