### PR TITLE
remove optional chaining because webpack 4 does not support it, and bringing support to it is far harder.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,8 +122,11 @@ function convertUnconventionalData(data: unknown) {
   result = Object.keys(result).reduce((acc, key) => {
     try {
       // Try accessing a property to test if we are allowed to do so
-      // eslint-disable-next-line no-unused-expressions, @typescript-eslint/no-unused-expressions
-      result[key]?.toJSON;
+      // We have a if statement, and not a optional chaining, because webpack4 doesn't support it, and react-native uses it
+      if (result[key]) {
+        // eslint-disable-next-line no-unused-expressions, @typescript-eslint/no-unused-expressions
+        result[key].toJSON;
+      }
 
       acc[key] = result[key];
     } catch (err) {


### PR DESCRIPTION
This removed optional chaining in the source code, which remains in the `dist` because of our compilation target.

This syntax is a problem for webpack4, because it's internal parser is outdated.

Webpack4 is still used in the experimental version of storybook for react-native that @dannyhw is working on.

Of course this will eventually be replaced by webpack 5, or better yet, a completely prebuild manager like in storybook 7.0.
Till that time, it's best to avoid overly complex solutions on react-native side, and just not use this one feature.
A small cost to pay for easy of use elsewhere.