### PR TITLE
Feature: Allow error parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ yarn add telejson
 - Function
 - Class
 - Symbol
+- Error
 - etc.
 
 Also JSON doesn't support cyclic data structures.
@@ -115,6 +116,8 @@ Only relevant when using `stringify`.
 `allowRegExp`: When set to false, regular expressions will not be serialized. (default = true)
 
 `allowClass`: When set to false, class instances will not be serialized. (default = true)
+
+`allowError`: When set to false, error instances will not be serialized. (default = true)
 
 `allowDate`: When set to false, Date objects will not be serialized. (default = true)
 

--- a/test/common/__snapshots__/index.test.js.snap
+++ b/test/common/__snapshots__/index.test.js.snap
@@ -24,6 +24,7 @@ exports[`Dist parse 1`] = `
 Object {
   "cyclic": [Circular],
   "date": 2018-01-01T00:00:00.000Z,
+  "error": [SomeError: Custom error message],
   "fn1": [Function],
   "fn2": [Function],
   "fn3": [Function],
@@ -70,6 +71,19 @@ exports[`Dist space 1`] = `
   \\"foo\\": {
     \\"_constructor-name_\\": \\"Foo\\"
   },
+  \\"error\\": {
+    \\"__isConvertedError__\\": true,
+    \\"errorProperties\\": {
+      \\"cause\\": {
+        \\"code\\": \\"001\\"
+      },
+      \\"stack\\": \\"mocked stack to avoid inconsistent snapshots\\",
+      \\"aCustomProperty\\": true,
+      \\"name\\": \\"SomeError\\",
+      \\"message\\": \\"Custom error message\\",
+      \\"_constructor-name_\\": \\"SomeError\\"
+    }
+  },
   \\"nested\\": {
     \\"a\\": {
       \\"b\\": {
@@ -96,4 +110,4 @@ exports[`Dist space 1`] = `
 }"
 `;
 
-exports[`Dist stringify 1`] = `"{\\"regex1\\":\\"_regexp_|foo\\",\\"regex2\\":\\"_regexp_g|foo\\",\\"regex3\\":\\"_regexp_i|foo\\",\\"fn1\\":\\"_function_fn1|x => x + x\\",\\"fn2\\":\\"_function_x|function x(x) {return x - x;}\\",\\"fn3\\":\\"_function_fn3|function fn3() {return x / x;}\\",\\"fn4\\":\\"_function_fn4|function(x) {return x * x;}\\",\\"date\\":\\"_date_2018-01-01T00:00:00.000Z\\",\\"foo\\":{\\"_constructor-name_\\":\\"Foo\\"},\\"nested\\":{\\"a\\":{\\"b\\":{\\"c\\":{\\"d\\":{\\"e\\":{\\"f\\":{\\"g\\":{\\"h\\":{\\"i\\":{\\"j\\":\\"[Object]\\"}}}}}}}}}},\\"undef\\":\\"_undefined_\\",\\"cyclic\\":\\"_duplicate_[]\\"}"`;
+exports[`Dist stringify 1`] = `"{\\"regex1\\":\\"_regexp_|foo\\",\\"regex2\\":\\"_regexp_g|foo\\",\\"regex3\\":\\"_regexp_i|foo\\",\\"fn1\\":\\"_function_fn1|x => x + x\\",\\"fn2\\":\\"_function_x|function x(x) {return x - x;}\\",\\"fn3\\":\\"_function_fn3|function fn3() {return x / x;}\\",\\"fn4\\":\\"_function_fn4|function(x) {return x * x;}\\",\\"date\\":\\"_date_2018-01-01T00:00:00.000Z\\",\\"foo\\":{\\"_constructor-name_\\":\\"Foo\\"},\\"error\\":{\\"__isConvertedError__\\":true,\\"errorProperties\\":{\\"cause\\":{\\"code\\":\\"001\\"},\\"stack\\":\\"mocked stack to avoid inconsistent snapshots\\",\\"aCustomProperty\\":true,\\"name\\":\\"SomeError\\",\\"message\\":\\"Custom error message\\",\\"_constructor-name_\\":\\"SomeError\\"}},\\"nested\\":{\\"a\\":{\\"b\\":{\\"c\\":{\\"d\\":{\\"e\\":{\\"f\\":{\\"g\\":{\\"h\\":{\\"i\\":{\\"j\\":\\"[Object]\\"}}}}}}}}}},\\"undef\\":\\"_undefined_\\",\\"cyclic\\":\\"_duplicate_[]\\"}"`;

--- a/test/common/index.test.js
+++ b/test/common/index.test.js
@@ -14,7 +14,20 @@ function fn3() {
   return x / x;
 }
 
-class Foo {}
+class Foo { }
+
+class SomeError extends Error {
+  aCustomProperty = true;
+  stack = 'mocked stack to avoid inconsistent snapshots';
+
+  constructor() {
+    super('Custom error message', { cause: { code: '001' } });
+  }
+
+  get name() {
+    return 'SomeError';
+  }
+}
 
 const date = new Date('2018');
 
@@ -58,6 +71,7 @@ const data = {
   },
   date,
   foo: new Foo(),
+  error: new SomeError(),
   nested,
   undef,
 };
@@ -104,6 +118,15 @@ const tests = ({ stringify, parse }) => {
     expect(parsed.foo).toBeDefined();
     expect(parsed.foo.constructor.name).toBe('Foo');
     expect(parsed.foo instanceof Foo).toBe(false);
+
+    // test Error instance
+    expect(parsed.error).toBeDefined();
+    expect(parsed.error.message).toEqual('Custom error message');
+    expect(parsed.error.name).toEqual('SomeError');
+    expect(parsed.error.stack).toEqual(data.error.stack);
+    expect(parsed.error.cause).toEqual(data.error.cause);
+    expect(parsed.error.aCustomProperty).toEqual(data.error.aCustomProperty);
+    expect(parsed.error instanceof Error).toBe(true);
 
     expect(parsed.undef).toBeUndefined();
   });
@@ -346,8 +369,8 @@ const tests = ({ stringify, parse }) => {
       f: [1, 2, 3, 4, 5],
       g: undefined,
       h: null,
-      i: () => {},
-      j() {},
+      i: () => { },
+      j() { },
     };
 
     data.e = {
@@ -386,8 +409,8 @@ const tests = ({ stringify, parse }) => {
   });
 
   test('dots in keys', () => {
-    class Foo {}
-    class Bar {}
+    class Foo { }
+    class Bar { }
     const foo = new Foo();
     const bar = new Bar();
     const data = { 'foo.a': bar, foo: { a: foo }, 'foo.b': foo };
@@ -446,15 +469,15 @@ const tests = ({ stringify, parse }) => {
   });
 
   test('parcel example', () => {
-    class $123Class {}
+    class $123Class { }
 
     const example = new $123Class();
 
     const stringified = stringify({ example });
     const parsed = parse(stringified);
 
-    expect(parsed).toEqual({example: {}});
-  })
+    expect(parsed).toEqual({ example: {} });
+  });
 };
 
 describe('Dist', () => {


### PR DESCRIPTION
Telejson now supports Error instances as well via the `allowError` flag